### PR TITLE
Add Support for Buses

### DIFF
--- a/nationalrail/client_test.go
+++ b/nationalrail/client_test.go
@@ -5035,6 +5035,80 @@ func TestGetDepartures(t *testing.T) {
 			},
 			errAssert: assert.NoError,
 		},
+		"Success with buses": {
+			crs: nr.StationCodeGillinghamKent,
+			setupMock: func() *httptest.Server {
+				data, err := os.ReadFile(filepath.Join("testdata", "GetDepartureBoardResponseWithBuses.xml"))
+				require.NoError(t, err)
+
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write(data)
+					require.NoError(t, err)
+				}))
+				return ts
+			},
+			expectedStationBoard: &nr.StationBoard{
+				CRS:          nr.StationCodeLondonBridge,
+				LocationName: nr.StationNameLondonBridge,
+				Services: []*nr.Service{
+					{
+						ID:   "3108056LNDNBDE_",
+						Type: "train",
+						Destination: nr.Location{
+							CRS:  nr.StationCodeGillinghamKent,
+							Name: nr.StationNameGillinghamKent,
+							Via:  pstr("via Greenwich & Woolwich Arsenal"),
+						},
+						Origins: []*nr.Location{
+							{
+								CRS:  nr.StationCodeKentishTown,
+								Name: nr.StationNameKentishTown,
+							},
+						},
+						Length: 8,
+						Operator: nr.Operator{
+							Code: "TL",
+							Name: "Thameslink",
+						},
+						Platform:                 "4",
+						RetailServiceID:          pstr("TL353900"),
+						EstimatedTimeOfDeparture: pstr("22:22"),
+						ScheduledTimeOfDeparture: pstr("22:18"),
+					},
+					{
+						ID:   "3208056LNDNBDE_",
+						Type: "bus",
+						Destination: nr.Location{
+							CRS:  nr.StationCodeGillinghamKent,
+							Name: nr.StationNameGillinghamKent,
+							Via:  pstr("via Greenwich & Woolwich Arsenal"),
+						},
+						Origins: []*nr.Location{
+							{
+								CRS:  nr.StationCodeKentishTown,
+								Name: nr.StationNameKentishTown,
+							},
+						},
+						Operator: nr.Operator{
+							Code: "TL",
+							Name: "Thameslink",
+						},
+						Platform:                 "BUS",
+						RetailServiceID:          pstr("TL354900"),
+						EstimatedTimeOfDeparture: pstr("23:22"),
+						ScheduledTimeOfDeparture: pstr("23:18"),
+					},
+				},
+				PlatformAvailable: true,
+				Filters: nr.RequestFilters{
+					CRS:          nr.StationCodeGillinghamKent,
+					LocationName: nr.StationNameGillinghamKent,
+				},
+				GeneratedAt: timeFromRFC3339(t, "2024-01-03T22:14:23.3784418Z"),
+			},
+			errAssert: assert.NoError,
+		},
 		"Fail_BadCRS": {
 			crs: nr.CRSCode("test"),
 			setupMock: func() *httptest.Server {

--- a/nationalrail/client_test.go
+++ b/nationalrail/client_test.go
@@ -118,7 +118,7 @@ func TestGetArrivalsWithDetails(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform: 2,
+						Platform: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -423,7 +423,7 @@ func TestGetArrivalsWithDetails(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform: 2,
+						Platform: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -2308,7 +2308,7 @@ func TestGetArrivalsAndDeparturesWithDetails(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform: 2,
+						Platform: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -3876,7 +3876,7 @@ func TestGetArrivalsAndDeparturesWithDetails(t *testing.T) {
 							Code: "TL",
 							Name: "Thameslink",
 						},
-						Platform: 2,
+						Platform: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -4425,7 +4425,7 @@ func TestGetArrivals(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform:               2,
+						Platform:               "2",
 						ScheduledTimeOfArrival: pstr("20:57"),
 						DelayReason:            pstr("This train has been delayed by a problem currently under investigation"),
 					},
@@ -4488,7 +4488,7 @@ func TestGetArrivals(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform:               2,
+						Platform:               "2",
 						ScheduledTimeOfArrival: pstr("21:29"),
 					},
 					{
@@ -4586,7 +4586,7 @@ func TestGetArrivals(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform:               0,
+						Platform:               "0",
 						ScheduledTimeOfArrival: pstr("21:57"),
 					},
 				},
@@ -4797,7 +4797,7 @@ func TestGetArrivalsAndDepartures(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform:                 1,
+						Platform:                 "1",
 						ScheduledTimeOfArrival:   pstr("22:05"),
 						EstimatedTimeOfDeparture: pstr("On time"),
 						ScheduledTimeOfDeparture: pstr("22:05"),
@@ -4879,7 +4879,7 @@ func TestGetArrivalsAndDepartures(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform:                 1,
+						Platform:                 "1",
 						ScheduledTimeOfArrival:   pstr("22:22"),
 						EstimatedTimeOfDeparture: pstr("On time"),
 						ScheduledTimeOfDeparture: pstr("22:23"),
@@ -5020,7 +5020,7 @@ func TestGetDepartures(t *testing.T) {
 							Code: "TL",
 							Name: "Thameslink",
 						},
-						Platform:                 4,
+						Platform:                 "4",
 						RetailServiceID:          pstr("TL353900"),
 						EstimatedTimeOfDeparture: pstr("22:22"),
 						ScheduledTimeOfDeparture: pstr("22:18"),
@@ -5394,7 +5394,7 @@ func TestGetFastestDepartures(t *testing.T) {
 								Code: "SE",
 								Name: "Southeastern",
 							},
-							Platform:                 2,
+							Platform:                 "2",
 							ScheduledTimeOfArrival:   pstr("23:13"),
 							EstimatedTimeOfDeparture: pstr("On time"),
 							ScheduledTimeOfDeparture: pstr("23:18"),
@@ -5527,7 +5527,7 @@ func TestGetFastestDeparturesWithDetails(t *testing.T) {
 								Code: "TL",
 								Name: "Thameslink",
 							},
-							Platform:                 1,
+							Platform:                 "1",
 							RetailServiceID:          pstr("TL353900"),
 							ScheduledTimeOfArrival:   pstr("23:29"),
 							EstimatedTimeOfDeparture: pstr("On time"),
@@ -5829,7 +5829,7 @@ func TestGetNextDepartures(t *testing.T) {
 								Code: "SE",
 								Name: "Southeastern",
 							},
-							Platform:                 3,
+							Platform:                 "3",
 							ScheduledTimeOfArrival:   pstr("00:01"),
 							EstimatedTimeOfDeparture: pstr("On time"),
 							ScheduledTimeOfDeparture: pstr("00:01"),
@@ -6110,7 +6110,7 @@ func TestGetNextDeparturesWithDetails(t *testing.T) {
 								Code: "SE",
 								Name: "Southeastern",
 							},
-							Platform:                 3,
+							Platform:                 "3",
 							ScheduledTimeOfArrival:   pstr("00:01"),
 							EstimatedTimeOfDeparture: pstr("On time"),
 							ScheduledTimeOfDeparture: pstr("00:01"),
@@ -7148,7 +7148,7 @@ func TestGetServiceDetails(t *testing.T) {
 					Code: "SE",
 					Name: "Southeastern",
 				},
-				Platform: 3,
+				Platform: "3",
 				PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 					{
 						{

--- a/nationalrail/mapper.go
+++ b/nationalrail/mapper.go
@@ -182,6 +182,10 @@ func mapStationBoard(sbr soap.GetStationBoardResult) (*StationBoard, error) {
 		stationBoard.Services = append(stationBoard.Services, mapService(&service))
 	}
 
+	for _, service := range sbr.BusServices.Service {
+		stationBoard.Services = append(stationBoard.Services, mapService(&service))
+	}
+
 	return &stationBoard, nil
 }
 

--- a/nationalrail/models.go
+++ b/nationalrail/models.go
@@ -70,7 +70,7 @@ type Service struct {
 	EstimatedTimeOfDeparture *string `json:"estimated_time_of_departure"`
 	DelayReason              *string `json:"delay_reason"`
 	Length                   int     `json:"length"`
-	Platform                 int     `json:"platform"`
+	Platform                 string  `json:"platform"`
 }
 
 type ServiceDetails struct {
@@ -106,7 +106,7 @@ type ServiceDetails struct {
 	// and EstimatedTimeOfDeparture is not present.
 	ActualTimeOfDeparture *string `json:"actual_time_of_departure"`
 	Length                int     `json:"length"`
-	Platform              int     `json:"platform"`
+	Platform              string  `json:"platform"`
 	IsCancelled           bool    `json:"is_cancelled"`
 	DetachFront           bool    `json:"detach_front"`
 	IsReverseFormation    bool    `json:"is_reverse_formation"`

--- a/nationalrail/soap/models.go
+++ b/nationalrail/soap/models.go
@@ -238,6 +238,7 @@ type GetStationBoardResult struct {
 	NrccMessages       NrccMessages  `xml:"nrccMessages"`
 	PlatformAvailable  bool          `xml:"platformAvailable"`
 	TrainServices      TrainServices `xml:"trainServices"`
+	BusServices        BusServices   `xml:"busServices"`
 }
 
 type Location struct {
@@ -284,6 +285,10 @@ type Toilet struct {
 }
 
 type TrainServices struct {
+	Service []Service `xml:"service"`
+}
+
+type BusServices struct {
 	Service []Service `xml:"service"`
 }
 

--- a/nationalrail/soap/models.go
+++ b/nationalrail/soap/models.go
@@ -198,7 +198,7 @@ type GetServiceDetailsResult struct {
 	Etd                     *string                 `xml:"etd"`
 	Atd                     *string                 `xml:"atd"`
 	Length                  int                     `xml:"length"`
-	Platform                int                     `xml:"platform"`
+	Platform                string                  `xml:"platform"`
 	IsCancelled             bool                    `xml:"isCancelled"`
 	DetachFront             bool                    `xml:"detachFront"`
 	IsReverseFormation      bool                    `xml:"isReverseFormation"`
@@ -275,7 +275,7 @@ type Service struct {
 	Std                     *string                  `xml:"std"`
 	Etd                     *string                  `xml:"etd"`
 	Length                  int                      `xml:"length"`
-	Platform                int                      `xml:"platform"`
+	Platform                string                   `xml:"platform"`
 }
 
 type Toilet struct {

--- a/nationalrail/testdata/GetDepartureBoardResponseWithBuses.xml
+++ b/nationalrail/testdata/GetDepartureBoardResponseWithBuses.xml
@@ -1,0 +1,65 @@
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetDepartureBoardResponse xmlns="http://thalesgroup.com/RTTI/2021-11-01/ldb/">
+            <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types" xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types" xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types" xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types" xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types" xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types" xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types" xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2024-01-03T22:14:23.3784418+00:00</lt4:generatedAt>
+                <lt4:locationName>London Bridge</lt4:locationName>
+                <lt4:crs>LBG</lt4:crs>
+                <lt4:filterLocationName>Gillingham (Kent)</lt4:filterLocationName>
+                <lt4:filtercrs>GLM</lt4:filtercrs>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt8:trainServices>
+                    <lt8:service>
+                        <lt4:std>22:18</lt4:std>
+                        <lt4:etd>22:22</lt4:etd>
+                        <lt4:platform>4</lt4:platform>
+                        <lt4:operator>Thameslink</lt4:operator>
+                        <lt4:operatorCode>TL</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:length>8</lt4:length>
+                        <lt4:serviceID>3108056LNDNBDE_</lt4:serviceID>
+                        <lt5:rsid>TL353900</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Kentish Town</lt4:locationName>
+                                <lt4:crs>KTN</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Gillingham (Kent)</lt4:locationName>
+                                <lt4:crs>GLM</lt4:crs>
+                                <lt4:via>via Greenwich &amp; Woolwich Arsenal</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt8:service>
+                </lt8:trainServices>
+                <lt8:busServices>
+                    <lt8:service>
+                        <lt4:std>23:18</lt4:std>
+                        <lt4:etd>23:22</lt4:etd>
+                        <lt4:platform>BUS</lt4:platform>
+                        <lt4:operator>Thameslink</lt4:operator>
+                        <lt4:operatorCode>TL</lt4:operatorCode>
+                        <lt4:serviceType>bus</lt4:serviceType>
+                        <lt4:serviceID>3208056LNDNBDE_</lt4:serviceID>
+                        <lt5:rsid>TL354900</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Kentish Town</lt4:locationName>
+                                <lt4:crs>KTN</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Gillingham (Kent)</lt4:locationName>
+                                <lt4:crs>GLM</lt4:crs>
+                                <lt4:via>via Greenwich &amp; Woolwich Arsenal</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt8:service>
+                </lt8:busServices>
+            </GetStationBoardResult>
+        </GetDepartureBoardResponse>
+    </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
## Description

Currently bus (rail replacement) services are not shown. This fixes that by adding parsing of bus services, to support this platform has been changed to a string type. This is required as the bus type platform is generally BUS but also required to support alphanumeric platforms (for example Stratford 3A).

## Type of change
- [X] New feature
- [X] Breaking change (platform int -> string)

## How Has This Been Tested?

Created synthetic bus service data based on live bus service data. Most importantly platform -> BUS, serviceType -> bus.