### PR TITLE
Support alphanumeric platform numbers

### DIFF
--- a/nationalrail/client_test.go
+++ b/nationalrail/client_test.go
@@ -118,7 +118,8 @@ func TestGetArrivalsWithDetails(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform: 2,
+						Platform:       2,
+						PlatformString: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -423,7 +424,8 @@ func TestGetArrivalsWithDetails(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform: 2,
+						Platform:       2,
+						PlatformString: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -2104,6 +2106,42 @@ func TestGetArrivalsWithDetails(t *testing.T) {
 			},
 			errAssert: assert.NoError,
 		},
+		"Success_AlphanumericPlatform": {
+			crs: nr.StationCodeReading,
+			setupMock: func() *httptest.Server {
+				data, err := os.ReadFile(filepath.Join("testdata", "GetArrBoardWithDetailsResponse_AlphanumericPlatform.xml"))
+				require.NoError(t, err)
+
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write(data)
+					require.NoError(t, err)
+				}))
+				return ts
+			},
+			expectedStationBoard: &nr.StationBoard{
+				CRS:          nr.StationCodeReading,
+				LocationName: nr.StationNameReading,
+				Services: []*nr.Service{
+					{
+						ID:     "alphanumeric_service_id",
+						Type:   "train",
+						Length: 8,
+						Operator: nr.Operator{
+							Code: "GW",
+							Name: "Great Western Railway",
+						},
+						Platform:               10,
+						PlatformString:         "10A",
+						EstimatedTimeOfArrival: pstr("On time"),
+						ScheduledTimeOfArrival: pstr("09:23"),
+					},
+				},
+				PlatformAvailable: true,
+				GeneratedAt:       timeFromRFC3339(t, "2024-01-03T08:55:05.8471861Z"),
+			},
+			errAssert: assert.NoError,
+		},
 		"Fail_BadCRS": {
 			crs: nr.CRSCode("test"),
 			setupMock: func() *httptest.Server {
@@ -2171,6 +2209,7 @@ func TestGetArrivalsWithDetails(t *testing.T) {
 				assert.Equal(t, expectedService.Length, actualService.Length)
 				assert.Equal(t, expectedService.Operator, actualService.Operator)
 				assert.Equal(t, expectedService.Platform, actualService.Platform)
+				assert.Equal(t, expectedService.PlatformString, actualService.PlatformString)
 				assert.Equal(t, expectedService.RetailServiceID, actualService.RetailServiceID)
 				assert.Equal(t, expectedService.ScheduledTimeOfArrival, actualService.ScheduledTimeOfArrival)
 
@@ -2308,7 +2347,8 @@ func TestGetArrivalsAndDeparturesWithDetails(t *testing.T) {
 							Code: "SE",
 							Name: "Southeastern",
 						},
-						Platform: 2,
+						Platform:       2,
+						PlatformString: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -3876,7 +3916,8 @@ func TestGetArrivalsAndDeparturesWithDetails(t *testing.T) {
 							Code: "TL",
 							Name: "Thameslink",
 						},
-						Platform: 2,
+						Platform:       2,
+						PlatformString: "2",
 						PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 							{
 								{
@@ -4281,6 +4322,7 @@ func TestGetArrivalsAndDeparturesWithDetails(t *testing.T) {
 				assert.Equal(t, expectedService.Length, actualService.Length)
 				assert.Equal(t, expectedService.Operator, actualService.Operator)
 				assert.Equal(t, expectedService.Platform, actualService.Platform)
+				assert.Equal(t, expectedService.PlatformString, actualService.PlatformString)
 				assert.Equal(t, expectedService.RetailServiceID, actualService.RetailServiceID)
 				assert.Equal(t, expectedService.ScheduledTimeOfArrival, actualService.ScheduledTimeOfArrival)
 
@@ -4426,6 +4468,7 @@ func TestGetArrivals(t *testing.T) {
 							Name: "Southeastern",
 						},
 						Platform:               2,
+						PlatformString:         "2",
 						ScheduledTimeOfArrival: pstr("20:57"),
 						DelayReason:            pstr("This train has been delayed by a problem currently under investigation"),
 					},
@@ -4489,6 +4532,7 @@ func TestGetArrivals(t *testing.T) {
 							Name: "Southeastern",
 						},
 						Platform:               2,
+						PlatformString:         "2",
 						ScheduledTimeOfArrival: pstr("21:29"),
 					},
 					{
@@ -4669,6 +4713,7 @@ func TestGetArrivals(t *testing.T) {
 				assert.Equal(t, expectedService.Length, actualService.Length)
 				assert.Equal(t, expectedService.Operator, actualService.Operator)
 				assert.Equal(t, expectedService.Platform, actualService.Platform)
+				assert.Equal(t, expectedService.PlatformString, actualService.PlatformString)
 				assert.Equal(t, expectedService.ScheduledTimeOfArrival, actualService.ScheduledTimeOfArrival)
 
 				assert.ElementsMatch(t, expectedService.Origins, actualService.Origins)
@@ -4798,6 +4843,7 @@ func TestGetArrivalsAndDepartures(t *testing.T) {
 							Name: "Southeastern",
 						},
 						Platform:                 1,
+						PlatformString:           "1",
 						ScheduledTimeOfArrival:   pstr("22:05"),
 						EstimatedTimeOfDeparture: pstr("On time"),
 						ScheduledTimeOfDeparture: pstr("22:05"),
@@ -4880,6 +4926,7 @@ func TestGetArrivalsAndDepartures(t *testing.T) {
 							Name: "Southeastern",
 						},
 						Platform:                 1,
+						PlatformString:           "1",
 						ScheduledTimeOfArrival:   pstr("22:22"),
 						EstimatedTimeOfDeparture: pstr("On time"),
 						ScheduledTimeOfDeparture: pstr("22:23"),
@@ -4965,6 +5012,7 @@ func TestGetArrivalsAndDepartures(t *testing.T) {
 				assert.Equal(t, expectedService.Length, actualService.Length)
 				assert.Equal(t, expectedService.Operator, actualService.Operator)
 				assert.Equal(t, expectedService.Platform, actualService.Platform)
+				assert.Equal(t, expectedService.PlatformString, actualService.PlatformString)
 				assert.Equal(t, expectedService.ScheduledTimeOfArrival, actualService.ScheduledTimeOfArrival)
 
 				assert.ElementsMatch(t, expectedService.Origins, actualService.Origins)
@@ -5021,6 +5069,7 @@ func TestGetDepartures(t *testing.T) {
 							Name: "Thameslink",
 						},
 						Platform:                 4,
+						PlatformString:           "4",
 						RetailServiceID:          pstr("TL353900"),
 						EstimatedTimeOfDeparture: pstr("22:22"),
 						ScheduledTimeOfDeparture: pstr("22:18"),
@@ -5102,6 +5151,7 @@ func TestGetDepartures(t *testing.T) {
 				assert.Equal(t, expectedService.Length, actualService.Length)
 				assert.Equal(t, expectedService.Operator, actualService.Operator)
 				assert.Equal(t, expectedService.Platform, actualService.Platform)
+				assert.Equal(t, expectedService.PlatformString, actualService.PlatformString)
 				assert.Equal(t, expectedService.RetailServiceID, actualService.RetailServiceID)
 				assert.Equal(t, expectedService.ScheduledTimeOfArrival, actualService.ScheduledTimeOfArrival)
 
@@ -5395,6 +5445,7 @@ func TestGetFastestDepartures(t *testing.T) {
 								Name: "Southeastern",
 							},
 							Platform:                 2,
+							PlatformString:           "2",
 							ScheduledTimeOfArrival:   pstr("23:13"),
 							EstimatedTimeOfDeparture: pstr("On time"),
 							ScheduledTimeOfDeparture: pstr("23:18"),
@@ -5528,6 +5579,7 @@ func TestGetFastestDeparturesWithDetails(t *testing.T) {
 								Name: "Thameslink",
 							},
 							Platform:                 1,
+							PlatformString:           "1",
 							RetailServiceID:          pstr("TL353900"),
 							ScheduledTimeOfArrival:   pstr("23:29"),
 							EstimatedTimeOfDeparture: pstr("On time"),
@@ -5830,6 +5882,7 @@ func TestGetNextDepartures(t *testing.T) {
 								Name: "Southeastern",
 							},
 							Platform:                 3,
+							PlatformString:           "3",
 							ScheduledTimeOfArrival:   pstr("00:01"),
 							EstimatedTimeOfDeparture: pstr("On time"),
 							ScheduledTimeOfDeparture: pstr("00:01"),
@@ -6111,6 +6164,7 @@ func TestGetNextDeparturesWithDetails(t *testing.T) {
 								Name: "Southeastern",
 							},
 							Platform:                 3,
+							PlatformString:           "3",
 							ScheduledTimeOfArrival:   pstr("00:01"),
 							EstimatedTimeOfDeparture: pstr("On time"),
 							ScheduledTimeOfDeparture: pstr("00:01"),
@@ -7148,7 +7202,8 @@ func TestGetServiceDetails(t *testing.T) {
 					Code: "SE",
 					Name: "Southeastern",
 				},
-				Platform: 3,
+				Platform:       3,
+				PlatformString: "3",
 				PreviousCallingPointsPerOrigin: [][]*nr.CallingPoint{
 					{
 						{

--- a/nationalrail/mapper.go
+++ b/nationalrail/mapper.go
@@ -199,7 +199,8 @@ func mapService(s *soap.Service) *Service {
 			Code: s.OperatorCode,
 			Name: s.Operator,
 		},
-		Platform:        s.Platform,
+		Platform:        parsePlatform(s.Platform),
+		PlatformString:  s.Platform,
 		RetailServiceID: s.Rsid,
 		Formation: Formation{
 			Coaches: mapCoaches(s.Formation.Coaches.Coach),
@@ -368,7 +369,8 @@ func mapServiceDetails(s *soap.GetServiceDetailsResult) (*ServiceDetails, error)
 			Code: s.OperatorCode,
 			Name: s.Operator,
 		},
-		Platform:                 s.Platform,
+		Platform:                 parsePlatform(s.Platform),
+		PlatformString:           s.Platform,
 		Type:                     s.ServiceType,
 		ScheduledTimeOfArrival:   s.Sta,
 		EstimatedTimeOfArrival:   s.Eta,
@@ -436,3 +438,14 @@ func mapServiceDetails(s *soap.GetServiceDetailsResult) (*ServiceDetails, error)
 
 	return &serviceDetails, nil
 }
+
+func parsePlatform(p string) int {
+	var val int
+	var i int
+	for i < len(p) && p[i] >= '0' && p[i] <= '9' {
+		val = val*10 + int(p[i]-'0')
+		i++
+	}
+	return val
+}
+

--- a/nationalrail/models.go
+++ b/nationalrail/models.go
@@ -71,6 +71,7 @@ type Service struct {
 	DelayReason              *string `json:"delay_reason"`
 	Length                   int     `json:"length"`
 	Platform                 int     `json:"platform"`
+	PlatformString           string  `json:"platform_string"`
 }
 
 type ServiceDetails struct {
@@ -107,6 +108,7 @@ type ServiceDetails struct {
 	ActualTimeOfDeparture *string `json:"actual_time_of_departure"`
 	Length                int     `json:"length"`
 	Platform              int     `json:"platform"`
+	PlatformString        string  `json:"platform_string"`
 	IsCancelled           bool    `json:"is_cancelled"`
 	DetachFront           bool    `json:"detach_front"`
 	IsReverseFormation    bool    `json:"is_reverse_formation"`

--- a/nationalrail/soap/models.go
+++ b/nationalrail/soap/models.go
@@ -198,7 +198,7 @@ type GetServiceDetailsResult struct {
 	Etd                     *string                 `xml:"etd"`
 	Atd                     *string                 `xml:"atd"`
 	Length                  int                     `xml:"length"`
-	Platform                int                     `xml:"platform"`
+	Platform                string                  `xml:"platform"`
 	IsCancelled             bool                    `xml:"isCancelled"`
 	DetachFront             bool                    `xml:"detachFront"`
 	IsReverseFormation      bool                    `xml:"isReverseFormation"`
@@ -275,7 +275,7 @@ type Service struct {
 	Std                     *string                  `xml:"std"`
 	Etd                     *string                  `xml:"etd"`
 	Length                  int                      `xml:"length"`
-	Platform                int                      `xml:"platform"`
+	Platform                string                   `xml:"platform"`
 }
 
 type Toilet struct {

--- a/nationalrail/testdata/GetArrBoardWithDetailsResponse_AlphanumericPlatform.xml
+++ b/nationalrail/testdata/GetArrBoardWithDetailsResponse_AlphanumericPlatform.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <GetArrBoardWithDetailsResponse xmlns="http://thalesgroup.com/RTTI/2021-11-01/ldb/">
+      <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types" xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types" xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types" xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types" xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types" xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types" xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types" xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+        <lt4:generatedAt>2024-01-03T08:55:05.8471861+00:00</lt4:generatedAt>
+        <lt4:locationName>Reading</lt4:locationName>
+        <lt4:crs>RDG</lt4:crs>
+        <lt4:platformAvailable>true</lt4:platformAvailable>
+        <lt8:trainServices>
+          <lt8:service>
+            <lt4:sta>09:23</lt4:sta>
+            <lt4:eta>On time</lt4:eta>
+            <lt4:platform>10A</lt4:platform>
+            <lt4:operator>Great Western Railway</lt4:operator>
+            <lt4:operatorCode>GW</lt4:operatorCode>
+            <lt4:serviceType>train</lt4:serviceType>
+            <lt4:length>8</lt4:length>
+            <lt4:serviceID>alphanumeric_service_id</lt4:serviceID>
+          </lt8:service>
+        </lt8:trainServices>
+      </GetStationBoardResult>
+    </GetArrBoardWithDetailsResponse>
+  </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
This PR adds support for alphanumeric platform numbers (such as `1B` or `3A`) from the National Rail SOAP service.

Currently, the SOAP models parse the `platform` field as an integer. This causes issues for stations that use alphanumeric platforms, leading to XML parsing or mapping failures.

### Changes:
1. Updated `soap.Service` and `soap.GetServiceDetailsResult` to model the `Platform` field as a `string`.
2. Created a new helper `parsePlatform(string) int` in `nationalrail/mapper.go` to parse the leading numeric digits from the platform string, preserving the legacy `Platform int` field for backward compatibility.
3. Added a new `PlatformString string` field to public models (`Service` and `ServiceDetails`) to expose the original alphanumeric platform string to API clients.
4. Added test coverage and mock XML test data reflecting alphanumeric platforms to verify mapping and handling correctness.